### PR TITLE
feature: QDのutilからutil_calcに移植し，戻り値で返していた計算結果をポインタに渡すように実装

### DIFF
--- a/QD-FFT/.clang-format
+++ b/QD-FFT/.clang-format
@@ -18,3 +18,5 @@ IndentCaseLabels: true
 IndentWidth: 4
 NamespaceIndentation: All
 Standard: Cpp11
+BinPackArguments: false
+BinPackParameters: true

--- a/QD-FFT/.vscode/c_cpp_properties.json
+++ b/QD-FFT/.vscode/c_cpp_properties.json
@@ -1,14 +1,17 @@
 {
-  "configurations": [
-    {
-      "name": "Linux",
-      "includePath": ["${workspaceFolder}/include", "/usr/local/include"],
-      "defines": [],
-      "compilerPath": "/usr/bin/gcc",
-      "cStandard": "c17",
-      "cppStandard": "c++17",
-      "configurationProvider": "ms-vscode.cmake-tools"
-    }
-  ],
-  "version": 4
+    "configurations": [
+        {
+            "name": "Linux",
+            "includePath": [
+                "${workspaceFolder}/include",
+                "/usr/local/include"
+            ],
+            "defines": [],
+            "compilerPath": "/usr/bin/gcc",
+            "cStandard": "c17",
+            "cppStandard": "c++17",
+            "configurationProvider": "ms-vscode.cmake-tools"
+        }
+    ],
+    "version": 4
 }

--- a/QD-FFT/include/util_calc.hpp
+++ b/QD-FFT/include/util_calc.hpp
@@ -1,0 +1,18 @@
+#pragma once
+
+namespace util::calc {
+    void split(double a, double* a_hi, double* a_lo);
+    void quick_two_sum(double a, double b, double* s, double* e);
+    void two_sum(double a, double b, double* s, double* e);
+    void three_sum(double a, double b, double c, double* s, double* e0,
+                   double* e1);
+    void three_sum(double a, double b, double c, double* s, double* e0);
+    void two_prod(double a, double b, double* p, double* e);
+    void six_three_sum(double a, double b, double c, double d, double e,
+                       double f, double* s, double* e0, double* e1);
+    void dd_add_dd_dd(double a0, double a1, double b0, double b1, double* s0,
+                      double* s1);
+    void nine_two_sum(double a, double b, double c, double d, double e,
+                      double f, double g, double h, double i, double* s,
+                      double* e0);
+}  // namespace util::calc

--- a/QD-FFT/src/CMakeLists.txt
+++ b/QD-FFT/src/CMakeLists.txt
@@ -1,0 +1,8 @@
+add_library(util_calc
+    STATIC
+        util_calc.cpp
+    )
+
+target_include_directories(util_calc
+    PUBLIC ${PROJECT_SOURCE_DIR}/include
+    )

--- a/QD-FFT/src/util_calc.cpp
+++ b/QD-FFT/src/util_calc.cpp
@@ -1,0 +1,80 @@
+#include "util_calc.hpp"
+
+namespace util::calc {
+    void split(double a, double* a_hi, double* a_lo) {
+        *a_hi = (double)((1 << 27) + 1) * a;
+        *a_hi = *a_hi - (*a_hi - a);
+        *a_lo = a - *a_hi;
+    }
+
+    void quick_two_sum(double a, double b, double* s, double* e) {
+        *s = a + b;
+        *e = b - (*s - a);
+    }
+
+    void two_sum(double a, double b, double* s, double* e) {
+        *s       = a + b;
+        double v = *s - a;
+        *e       = (a - (*s - v)) + (b - v);
+    }
+
+    void three_sum(double a, double b, double c, double* s, double* e0,
+                   double* e1) {
+        two_sum(a, b, s, e0);
+        two_sum(*s, c, s, e1);
+        two_sum(*e0, *e1, e0, e1);
+    }
+
+    void three_sum(double a, double b, double c, double* s, double* e0) {
+        double e1;
+        two_sum(a, b, s, e0);
+        two_sum(*s, c, s, &e1);
+        *e0 += e1;
+    }
+
+    void two_prod(double a, double b, double* p, double* e) {
+        double a_hi, a_lo, b_hi, b_lo;
+        *p = a * b;
+        split(a, &a_hi, &a_lo);
+        split(b, &b_hi, &b_lo);
+        *e = ((a_hi * b_hi - *p) + a_hi * b_lo + a_lo * b_hi) + a_lo * b_lo;
+    }
+
+    void six_three_sum(double a, double b, double c, double d, double e,
+                       double f, double* s, double* e0, double* e1) {
+        double t[3];
+        three_sum(a, b, c, s, e0, e1);
+        three_sum(d, e, f, t, t + 1, t + 2);
+        two_sum(*s, t[0], s, t);
+        two_sum(*e0, t[1], e0, t + 1);
+        two_sum(*e0, t[0], e0, t);
+        *e1 += t[2];
+        *e1 += t[1];
+        *e1 += t[0];
+    }
+
+    void dd_add_dd_dd(double a0, double a1, double b0, double b1, double* s0,
+                      double* s1) {
+        double t[2];
+        two_sum(a0, b0, s0, s1);
+        two_sum(a1, b1, t, t + 1);
+        *s1 += t[0];
+        quick_two_sum(*s0, *s1, s0, s1);
+        *s1 += t[1];
+        quick_two_sum(*s0, *s1, s0, s1);
+    }
+
+    void nine_two_sum(double a, double b, double c, double d, double e,
+                      double f, double g, double h, double i, double* s,
+                      double* e0) {
+        double t[6];
+        two_sum(a, b, s, e0);
+        two_sum(c, d, t, t + 1);
+        dd_add_dd_dd(*s, *e0, t[0], t[1], s, e0);
+        two_sum(e, f, t, t + 1);
+        two_sum(g, h, t + 2, t + 3);
+        dd_add_dd_dd(t[0], t[1], t[2], t[3], &t[0], &t[1]);
+        dd_add_dd_dd(*s, *e0, t[0], t[1], s, e0);
+        three_sum(i, *s, *e0, s, e0);
+    }
+}  // namespace util::calc


### PR DESCRIPTION
QDのutilからdouble同士の計算結果とエラーを求める関数群をutil_calcのutil::calcに移植した．
加えて，戻り値で計算結果を返していたが，引数に計算結果を渡すdoubleポインタを加えて，そこに渡すように実装した．