### PR TITLE
fix: inlineのため，未定義とコンパイルエラーが出るため，inlineを削除

### DIFF
--- a/QD-FFT/include/qd.hpp
+++ b/QD-FFT/include/qd.hpp
@@ -3,16 +3,18 @@
 namespace QD {
 using qd = double[4];
 
-inline void zero(qd a);
-inline void init(qd a, double x0);
-inline void init(qd a, double x0, double x1, double x2, double x3);
-inline void copy(const qd a, qd b);
+// util
+void zero(qd a);
+void init(qd a, double x0);
+void init(qd a, double x0, double x1, double x2, double x3);
+void copy(const qd a, qd b);
 
+// calc
 void renormalize(qd a);
 void renormalize(qd a, double b);
 
-inline void minus(const qd a, qd b);
-inline void minus(qd a);
+void minus(const qd a, qd b);
+void minus(qd a);
 
 void add(const qd a, const qd b, qd s);
 void add(const qd a, double b, qd s);

--- a/QD-FFT/src/qd_util.cpp
+++ b/QD-FFT/src/qd_util.cpp
@@ -1,42 +1,42 @@
 #include "qd.hpp"
 
 namespace QD {
-inline void zero(qd a) {
+void zero(qd a) {
     a[0] = 0.0;
     a[1] = 0.0;
     a[2] = 0.0;
     a[3] = 0.0;
 }
 
-inline void init(qd a, double x0) {
+void init(qd a, double x0) {
     a[0] = x0;
     a[1] = 0.0;
     a[2] = 0.0;
     a[3] = 0.0;
 }
 
-inline void init(qd a, double x0, double x1, double x2, double x3) {
+void init(qd a, double x0, double x1, double x2, double x3) {
     a[0] = x0;
     a[1] = x1;
     a[2] = x2;
     a[3] = x3;
 }
 
-inline void copy(const qd a, qd b) {
+void copy(const qd a, qd b) {
     b[0] = a[0];
     b[1] = a[1];
     b[2] = a[2];
     b[3] = a[3];
 }
 
-inline void minus(const qd a, qd b) {
+void minus(const qd a, qd b) {
     b[0] = -a[0];
     b[1] = -a[1];
     b[2] = -a[2];
     b[3] = -a[3];
 }
 
-inline void minus(qd a) {
+void minus(qd a) {
     a[0] = -a[0];
     a[1] = -a[1];
     a[2] = -a[2];


### PR DESCRIPTION
inlineのため，未定義とコンパイルエラーが出るため, inlineを削除