### PR TITLE
fix: nine_two_sumとsqrtに存在したバグを修正

### DIFF
--- a/QD-FFT/src/qd.cpp
+++ b/QD-FFT/src/qd.cpp
@@ -251,7 +251,7 @@ void sqr(const qd a, qd p) {
 }
 
 void sqrt(const qd a, qd b) {
-    if (a[0] != 0.0 || a[1] != 0.0 || a[2] != 0.0 || a[3] == 0.0) {
+    if (a[0] != 0.0 || a[1] != 0.0 || a[2] != 0.0 || a[3] != 0.0) {
         qd h;
         qd t0, t1;
         mul_pwr2(a, 0.5, h);
@@ -1331,6 +1331,7 @@ void cos(unsigned long long int k, unsigned long long int n, qd a) {
             return;
         }
         copy(cos_table_2048[k], a);
+        return;
     }
 
     unsigned long long int harf_n = n >> 1;

--- a/QD-FFT/src/util_calc.cpp
+++ b/QD-FFT/src/util_calc.cpp
@@ -74,7 +74,7 @@ void nine_two_sum(double a, double b, double c, double d, double e, double f,
     dd_add_dd_dd(*s, *e0, t[0], t[1], s, e0);
     two_sum(e, f, t, t + 1);
     two_sum(g, h, t + 2, t + 3);
-    dd_add_dd_dd(t[0], t[1], t[2], t[3], &t[0], &t[1]);
+    dd_add_dd_dd(t[0], t[1], t[2], t[3], t, t + 1);
     dd_add_dd_dd(*s, *e0, t[0], t[1], s, e0);
     three_sum(i, *s, *e0, s, e0);
 }


### PR DESCRIPTION
sqrtの
if (a[0] != 0.0 || a[1] != 0.0 || a[2] != 0.0 || a[3] == 0.0)
を
if (a[0] != 0.0 || a[1] != 0.0 || a[2] != 0.0 || a[3] != 0.0)
に修正

nine_two_sumのポインタアクセスを
dd_add_dd_dd(t[0], t[1], t[2], t[3], t, t + 1)
に修正